### PR TITLE
Fix/Uncomment 'FOTO' column in users index view

### DIFF
--- a/resources/views/users/index.blade.php
+++ b/resources/views/users/index.blade.php
@@ -26,7 +26,7 @@
                                     <thead>
                                         <tr>
                                             <th>ID</th>
-                                            {{-- <th>FOTO</th> --}}
+                                            <th>FOTO</th>
                                             <th>NOMBRE</th>
                                             <th>TELEFONO</th>
                                             <th>EMAIL</th>


### PR DESCRIPTION
## Summary
This pull request includes a small change to the `resources/views/users/index.blade.php` file. The change re-enables the "FOTO" column in the users table.

* [`resources/views/users/index.blade.php`](diffhunk://#diff-027024064eaf4abae43cafb9cf2a8b59f4a4da55ee6308940132acfcba236a59L29-R29): Uncommented the "FOTO" column header in the table.